### PR TITLE
Variable length arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+* Arithmetic expressions `Add`, `Subtract`, `Multiply`, `Divide` and `Modulo` now accept variable number of additional arguments beyond the first two
+
 ## [0.9.0] - 2023-11-30
 ### Added
 * Case-when syntax

--- a/src/Operator/Arithmetic/Add.php
+++ b/src/Operator/Arithmetic/Add.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tpetry\QueryExpressions\Operator\Arithmetic;
 
-use Tpetry\QueryExpressions\Operator\OperatorExpression;
+use Tpetry\QueryExpressions\Operator\VariableLengthOperatorExpression;
 
-class Add extends OperatorExpression
+class Add extends VariableLengthOperatorExpression
 {
     protected function operator(): string
     {

--- a/src/Operator/Arithmetic/Divide.php
+++ b/src/Operator/Arithmetic/Divide.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tpetry\QueryExpressions\Operator\Arithmetic;
 
-use Tpetry\QueryExpressions\Operator\OperatorExpression;
+use Tpetry\QueryExpressions\Operator\VariableLengthOperatorExpression;
 
-class Divide extends OperatorExpression
+class Divide extends VariableLengthOperatorExpression
 {
     protected function operator(): string
     {

--- a/src/Operator/Arithmetic/Modulo.php
+++ b/src/Operator/Arithmetic/Modulo.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tpetry\QueryExpressions\Operator\Arithmetic;
 
-use Tpetry\QueryExpressions\Operator\OperatorExpression;
+use Tpetry\QueryExpressions\Operator\VariableLengthOperatorExpression;
 
-class Modulo extends OperatorExpression
+class Modulo extends VariableLengthOperatorExpression
 {
     protected function operator(): string
     {

--- a/src/Operator/Arithmetic/Multiply.php
+++ b/src/Operator/Arithmetic/Multiply.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tpetry\QueryExpressions\Operator\Arithmetic;
 
-use Tpetry\QueryExpressions\Operator\OperatorExpression;
+use Tpetry\QueryExpressions\Operator\VariableLengthOperatorExpression;
 
-class Multiply extends OperatorExpression
+class Multiply extends VariableLengthOperatorExpression
 {
     protected function operator(): string
     {

--- a/src/Operator/Arithmetic/Subtract.php
+++ b/src/Operator/Arithmetic/Subtract.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Tpetry\QueryExpressions\Operator\Arithmetic;
 
-use Tpetry\QueryExpressions\Operator\OperatorExpression;
+use Tpetry\QueryExpressions\Operator\VariableLengthOperatorExpression;
 
-class Subtract extends OperatorExpression
+class Subtract extends VariableLengthOperatorExpression
 {
     protected function operator(): string
     {

--- a/src/Operator/VariableLengthOperatorExpression.php
+++ b/src/Operator/VariableLengthOperatorExpression.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tpetry\QueryExpressions\Operator;
+
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Grammar;
+
+/**
+ * @internal
+ */
+abstract class VariableLengthOperatorExpression extends OperatorExpression
+{
+    private array $values = [];
+
+    public function __construct(
+        private readonly string|Expression $value1,
+        private readonly string|Expression $value2,
+        string|Expression ...$values,
+    ) {
+        $this->values = $values;
+    }
+
+    public function getValue(Grammar $grammar): string
+    {
+        $value = "{$this->stringize($grammar, $this->value1)} {$this->operator()} {$this->stringize($grammar, $this->value2)}";
+
+        foreach ($this->values as $additional) {
+            $value .= " {$this->operator()} {$this->stringize($grammar, $additional)}";
+        }
+
+        return "({$value})";
+    }
+}

--- a/tests/Operator/Arithmetic/AddTest.php
+++ b/tests/Operator/Arithmetic/AddTest.php
@@ -44,3 +44,103 @@ it('can add a column and an expression')
     ->toBePgsql('(0 + "val")')
     ->toBeSqlite('(0 + "val")')
     ->toBeSqlsrv('(0 + [val])');
+
+it('can add many columns', function ($columns, $expectations) {
+    expect(new Add(...$columns))
+        ->toBeExecutable(function (Blueprint $table) use ($columns) {
+            foreach ($columns as $column) {
+                $table->integer($column);
+            }
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        ['val1', 'val2', 'val3'],
+        [
+            'mysql' => '(`val1` + `val2` + `val3`)',
+            'pgsql' => '("val1" + "val2" + "val3")',
+            'sqlite' => '("val1" + "val2" + "val3")',
+            'sqlsrv' => '([val1] + [val2] + [val3])',
+        ],
+    ],
+    'eight' => [
+        ['val1', 'val2', 'val3', 'val4', 'val5', 'val6', 'val7', 'val8'],
+        [
+            'mysql' => '(`val1` + `val2` + `val3` + `val4` + `val5` + `val6` + `val7` + `val8`)',
+            'pgsql' => '("val1" + "val2" + "val3" + "val4" + "val5" + "val6" + "val7" + "val8")',
+            'sqlite' => '("val1" + "val2" + "val3" + "val4" + "val5" + "val6" + "val7" + "val8")',
+            'sqlsrv' => '([val1] + [val2] + [val3] + [val4] + [val5] + [val6] + [val7] + [val8])',
+        ],
+    ],
+]);
+
+it('can add many expressions', function ($values, $expectations) {
+    $expressions = array_map(fn ($value) => new Expression($value), $values);
+
+    expect(new Add(...$expressions))
+        ->toBeExecutable()
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        [1, 2, 3],
+        [
+            'mysql' => '(1 + 2 + 3)',
+            'pgsql' => '(1 + 2 + 3)',
+            'sqlite' => '(1 + 2 + 3)',
+            'sqlsrv' => '(1 + 2 + 3)',
+        ],
+    ],
+    'eight' => [
+        [1, 2, 3, 4, 5, 6, 7, 8],
+        [
+            'mysql' => '(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8)',
+            'pgsql' => '(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8)',
+            'sqlite' => '(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8)',
+            'sqlsrv' => '(1 + 2 + 3 + 4 + 5 + 6 + 7 + 8)',
+        ],
+    ],
+]);
+
+it('can add many expressions and columns', function (array $values, array $expectations) {
+    $expressions = array_map(
+        fn ($value) => is_int($value)
+            ? new Expression($value)
+            : $value,
+        $values
+    );
+
+    expect(new Add(...$expressions))
+        ->toBeExecutable(function (Blueprint $table) {
+            $table->integer('val1');
+            $table->integer('val2');
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'expression/column/...' => [
+        ['val1', 1, 'val2', 2],
+        [
+            'mysql' => '(`val1` + 1 + `val2` + 2)',
+            'pgsql' => '("val1" + 1 + "val2" + 2)',
+            'sqlite' => '("val1" + 1 + "val2" + 2)',
+            'sqlsrv' => '([val1] + 1 + [val2] + 2)',
+        ],
+    ],
+    'column/expression/...' => [
+        [1, 'val1', 2, 'val2'],
+        [
+            'mysql' => '(1 + `val1` + 2 + `val2`)',
+            'pgsql' => '(1 + "val1" + 2 + "val2")',
+            'sqlite' => '(1 + "val1" + 2 + "val2")',
+            'sqlsrv' => '(1 + [val1] + 2 + [val2])',
+        ],
+    ],
+]);

--- a/tests/Operator/Arithmetic/DivideTest.php
+++ b/tests/Operator/Arithmetic/DivideTest.php
@@ -44,3 +44,103 @@ it('can divide a column and an expression')
     ->toBePgsql('(0 / "val")')
     ->toBeSqlite('(0 / "val")')
     ->toBeSqlsrv('(0 / [val])');
+
+it('can divide many columns', function ($columns, $expectations) {
+    expect(new Divide(...$columns))
+        ->toBeExecutable(function (Blueprint $table) use ($columns) {
+            foreach ($columns as $column) {
+                $table->integer($column);
+            }
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        ['val1', 'val2', 'val3'],
+        [
+            'mysql' => '(`val1` / `val2` / `val3`)',
+            'pgsql' => '("val1" / "val2" / "val3")',
+            'sqlite' => '("val1" / "val2" / "val3")',
+            'sqlsrv' => '([val1] / [val2] / [val3])',
+        ],
+    ],
+    'eight' => [
+        ['val1', 'val2', 'val3', 'val4', 'val5', 'val6', 'val7', 'val8'],
+        [
+            'mysql' => '(`val1` / `val2` / `val3` / `val4` / `val5` / `val6` / `val7` / `val8`)',
+            'pgsql' => '("val1" / "val2" / "val3" / "val4" / "val5" / "val6" / "val7" / "val8")',
+            'sqlite' => '("val1" / "val2" / "val3" / "val4" / "val5" / "val6" / "val7" / "val8")',
+            'sqlsrv' => '([val1] / [val2] / [val3] / [val4] / [val5] / [val6] / [val7] / [val8])',
+        ],
+    ],
+]);
+
+it('can divide many expressions', function ($values, $expectations) {
+    $expressions = array_map(fn ($value) => new Expression($value), $values);
+
+    expect(new Divide(...$expressions))
+        ->toBeExecutable()
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        [1, 2, 3],
+        [
+            'mysql' => '(1 / 2 / 3)',
+            'pgsql' => '(1 / 2 / 3)',
+            'sqlite' => '(1 / 2 / 3)',
+            'sqlsrv' => '(1 / 2 / 3)',
+        ],
+    ],
+    'eight' => [
+        [1, 2, 3, 4, 5, 6, 7, 8],
+        [
+            'mysql' => '(1 / 2 / 3 / 4 / 5 / 6 / 7 / 8)',
+            'pgsql' => '(1 / 2 / 3 / 4 / 5 / 6 / 7 / 8)',
+            'sqlite' => '(1 / 2 / 3 / 4 / 5 / 6 / 7 / 8)',
+            'sqlsrv' => '(1 / 2 / 3 / 4 / 5 / 6 / 7 / 8)',
+        ],
+    ],
+]);
+
+it('can divide many expressions and columns', function (array $values, array $expectations) {
+    $expressions = array_map(
+        fn ($value) => is_int($value)
+            ? new Expression($value)
+            : $value,
+        $values
+    );
+
+    expect(new Divide(...$expressions))
+        ->toBeExecutable(function (Blueprint $table) {
+            $table->integer('val1');
+            $table->integer('val2');
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'expression/column/...' => [
+        ['val1', 1, 'val2', 2],
+        [
+            'mysql' => '(`val1` / 1 / `val2` / 2)',
+            'pgsql' => '("val1" / 1 / "val2" / 2)',
+            'sqlite' => '("val1" / 1 / "val2" / 2)',
+            'sqlsrv' => '([val1] / 1 / [val2] / 2)',
+        ],
+    ],
+    'column/expression/...' => [
+        [1, 'val1', 2, 'val2'],
+        [
+            'mysql' => '(1 / `val1` / 2 / `val2`)',
+            'pgsql' => '(1 / "val1" / 2 / "val2")',
+            'sqlite' => '(1 / "val1" / 2 / "val2")',
+            'sqlsrv' => '(1 / [val1] / 2 / [val2])',
+        ],
+    ],
+]);

--- a/tests/Operator/Arithmetic/ModuloTest.php
+++ b/tests/Operator/Arithmetic/ModuloTest.php
@@ -44,3 +44,103 @@ it('can modulo a column and an expression')
     ->toBePgsql('(0 % "val")')
     ->toBeSqlite('(0 % "val")')
     ->toBeSqlsrv('(0 % [val])');
+
+it('can modulo many columns', function ($columns, $expectations) {
+    expect(new Modulo(...$columns))
+        ->toBeExecutable(function (Blueprint $table) use ($columns) {
+            foreach ($columns as $column) {
+                $table->integer($column);
+            }
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        ['val1', 'val2', 'val3'],
+        [
+            'mysql' => '(`val1` % `val2` % `val3`)',
+            'pgsql' => '("val1" % "val2" % "val3")',
+            'sqlite' => '("val1" % "val2" % "val3")',
+            'sqlsrv' => '([val1] % [val2] % [val3])',
+        ],
+    ],
+    'eight' => [
+        ['val1', 'val2', 'val3', 'val4', 'val5', 'val6', 'val7', 'val8'],
+        [
+            'mysql' => '(`val1` % `val2` % `val3` % `val4` % `val5` % `val6` % `val7` % `val8`)',
+            'pgsql' => '("val1" % "val2" % "val3" % "val4" % "val5" % "val6" % "val7" % "val8")',
+            'sqlite' => '("val1" % "val2" % "val3" % "val4" % "val5" % "val6" % "val7" % "val8")',
+            'sqlsrv' => '([val1] % [val2] % [val3] % [val4] % [val5] % [val6] % [val7] % [val8])',
+        ],
+    ],
+]);
+
+it('can modulo many expressions', function (array $values, array $expectations) {
+    $expressions = array_map(fn ($value) => new Expression($value), $values);
+
+    expect(new Modulo(...$expressions))
+        ->toBeExecutable()
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        [1, 2, 3],
+        [
+            'mysql' => '(1 % 2 % 3)',
+            'pgsql' => '(1 % 2 % 3)',
+            'sqlite' => '(1 % 2 % 3)',
+            'sqlsrv' => '(1 % 2 % 3)',
+        ],
+    ],
+    'eight' => [
+        [1, 2, 3, 4, 5, 6, 7, 8],
+        [
+            'mysql' => '(1 % 2 % 3 % 4 % 5 % 6 % 7 % 8)',
+            'pgsql' => '(1 % 2 % 3 % 4 % 5 % 6 % 7 % 8)',
+            'sqlite' => '(1 % 2 % 3 % 4 % 5 % 6 % 7 % 8)',
+            'sqlsrv' => '(1 % 2 % 3 % 4 % 5 % 6 % 7 % 8)',
+        ],
+    ],
+]);
+
+it('can modulo many expressions and columns', function (array $values, array $expectations) {
+    $expressions = array_map(
+        fn ($value) => is_int($value)
+            ? new Expression($value)
+            : $value,
+        $values
+    );
+
+    expect(new Modulo(...$expressions))
+        ->toBeExecutable(function (Blueprint $table) {
+            $table->integer('val1');
+            $table->integer('val2');
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'expression/column/...' => [
+        ['val1', 1, 'val2', 2],
+        [
+            'mysql' => '(`val1` % 1 % `val2` % 2)',
+            'pgsql' => '("val1" % 1 % "val2" % 2)',
+            'sqlite' => '("val1" % 1 % "val2" % 2)',
+            'sqlsrv' => '([val1] % 1 % [val2] % 2)',
+        ],
+    ],
+    'column/expression/...' => [
+        [1, 'val1', 2, 'val2'],
+        [
+            'mysql' => '(1 % `val1` % 2 % `val2`)',
+            'pgsql' => '(1 % "val1" % 2 % "val2")',
+            'sqlite' => '(1 % "val1" % 2 % "val2")',
+            'sqlsrv' => '(1 % [val1] % 2 % [val2])',
+        ],
+    ],
+]);

--- a/tests/Operator/Arithmetic/MultiplyTest.php
+++ b/tests/Operator/Arithmetic/MultiplyTest.php
@@ -44,3 +44,103 @@ it('can multiply a column and an expression')
     ->toBePgsql('(0 * "val")')
     ->toBeSqlite('(0 * "val")')
     ->toBeSqlsrv('(0 * [val])');
+
+it('can multiply many columns', function ($columns, $expectations) {
+    expect(new Multiply(...$columns))
+        ->toBeExecutable(function (Blueprint $table) use ($columns) {
+            foreach ($columns as $column) {
+                $table->integer($column);
+            }
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        ['val1', 'val2', 'val3'],
+        [
+            'mysql' => '(`val1` * `val2` * `val3`)',
+            'pgsql' => '("val1" * "val2" * "val3")',
+            'sqlite' => '("val1" * "val2" * "val3")',
+            'sqlsrv' => '([val1] * [val2] * [val3])',
+        ],
+    ],
+    'eight' => [
+        ['val1', 'val2', 'val3', 'val4', 'val5', 'val6', 'val7', 'val8'],
+        [
+            'mysql' => '(`val1` * `val2` * `val3` * `val4` * `val5` * `val6` * `val7` * `val8`)',
+            'pgsql' => '("val1" * "val2" * "val3" * "val4" * "val5" * "val6" * "val7" * "val8")',
+            'sqlite' => '("val1" * "val2" * "val3" * "val4" * "val5" * "val6" * "val7" * "val8")',
+            'sqlsrv' => '([val1] * [val2] * [val3] * [val4] * [val5] * [val6] * [val7] * [val8])',
+        ],
+    ],
+]);
+
+it('can multiply many expressions', function (array $values, array $expectations) {
+    $expressions = array_map(fn ($value) => new Expression($value), $values);
+
+    expect(new Multiply(...$expressions))
+        ->toBeExecutable()
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        [1, 2, 3],
+        [
+            'mysql' => '(1 * 2 * 3)',
+            'pgsql' => '(1 * 2 * 3)',
+            'sqlite' => '(1 * 2 * 3)',
+            'sqlsrv' => '(1 * 2 * 3)',
+        ],
+    ],
+    'eight' => [
+        [1, 2, 3, 4, 5, 6, 7, 8],
+        [
+            'mysql' => '(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)',
+            'pgsql' => '(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)',
+            'sqlite' => '(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)',
+            'sqlsrv' => '(1 * 2 * 3 * 4 * 5 * 6 * 7 * 8)',
+        ],
+    ],
+]);
+
+it('can multiply many expressions and columns', function (array $values, array $expectations) {
+    $expressions = array_map(
+        fn ($value) => is_int($value)
+            ? new Expression($value)
+            : $value,
+        $values
+    );
+
+    expect(new Multiply(...$expressions))
+        ->toBeExecutable(function (Blueprint $table) {
+            $table->integer('val1');
+            $table->integer('val2');
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'expression/column/...' => [
+        ['val1', 1, 'val2', 2],
+        [
+            'mysql' => '(`val1` * 1 * `val2` * 2)',
+            'pgsql' => '("val1" * 1 * "val2" * 2)',
+            'sqlite' => '("val1" * 1 * "val2" * 2)',
+            'sqlsrv' => '([val1] * 1 * [val2] * 2)',
+        ],
+    ],
+    'column/expression/...' => [
+        [1, 'val1', 2, 'val2'],
+        [
+            'mysql' => '(1 * `val1` * 2 * `val2`)',
+            'pgsql' => '(1 * "val1" * 2 * "val2")',
+            'sqlite' => '(1 * "val1" * 2 * "val2")',
+            'sqlsrv' => '(1 * [val1] * 2 * [val2])',
+        ],
+    ],
+]);

--- a/tests/Operator/Arithmetic/SubtractTest.php
+++ b/tests/Operator/Arithmetic/SubtractTest.php
@@ -44,3 +44,103 @@ it('can subtract a column and an expression')
     ->toBePgsql('(0 - "val")')
     ->toBeSqlite('(0 - "val")')
     ->toBeSqlsrv('(0 - [val])');
+
+it('can subtract many columns', function ($columns, $expectations) {
+    expect(new Subtract(...$columns))
+        ->toBeExecutable(function (Blueprint $table) use ($columns) {
+            foreach ($columns as $column) {
+                $table->integer($column);
+            }
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        ['val1', 'val2', 'val3'],
+        [
+            'mysql' => '(`val1` - `val2` - `val3`)',
+            'pgsql' => '("val1" - "val2" - "val3")',
+            'sqlite' => '("val1" - "val2" - "val3")',
+            'sqlsrv' => '([val1] - [val2] - [val3])',
+        ],
+    ],
+    'eight' => [
+        ['val1', 'val2', 'val3', 'val4', 'val5', 'val6', 'val7', 'val8'],
+        [
+            'mysql' => '(`val1` - `val2` - `val3` - `val4` - `val5` - `val6` - `val7` - `val8`)',
+            'pgsql' => '("val1" - "val2" - "val3" - "val4" - "val5" - "val6" - "val7" - "val8")',
+            'sqlite' => '("val1" - "val2" - "val3" - "val4" - "val5" - "val6" - "val7" - "val8")',
+            'sqlsrv' => '([val1] - [val2] - [val3] - [val4] - [val5] - [val6] - [val7] - [val8])',
+        ],
+    ],
+]);
+
+it('can subtract many expressions', function (array $values, array $expectations) {
+    $expressions = array_map(fn ($value) => new Expression($value), $values);
+
+    expect(new Subtract(...$expressions))
+        ->toBeExecutable()
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'three' => [
+        [1, 2, 3],
+        [
+            'mysql' => '(1 - 2 - 3)',
+            'pgsql' => '(1 - 2 - 3)',
+            'sqlite' => '(1 - 2 - 3)',
+            'sqlsrv' => '(1 - 2 - 3)',
+        ],
+    ],
+    'eight' => [
+        [1, 2, 3, 4, 5, 6, 7, 8],
+        [
+            'mysql' => '(1 - 2 - 3 - 4 - 5 - 6 - 7 - 8)',
+            'pgsql' => '(1 - 2 - 3 - 4 - 5 - 6 - 7 - 8)',
+            'sqlite' => '(1 - 2 - 3 - 4 - 5 - 6 - 7 - 8)',
+            'sqlsrv' => '(1 - 2 - 3 - 4 - 5 - 6 - 7 - 8)',
+        ],
+    ],
+]);
+
+it('can subtract many expressions and columns', function (array $values, array $expectations) {
+    $expressions = array_map(
+        fn ($value) => is_int($value)
+            ? new Expression($value)
+            : $value,
+        $values
+    );
+
+    expect(new Subtract(...$expressions))
+        ->toBeExecutable(function (Blueprint $table) {
+            $table->integer('val1');
+            $table->integer('val2');
+        })
+        ->toBeMysql($expectations['mysql'])
+        ->toBePgsql($expectations['pgsql'])
+        ->toBeSqlite($expectations['sqlite'])
+        ->toBeSqlsrv($expectations['sqlsrv']);
+})->with([
+    'expression/column/...' => [
+        ['val1', 1, 'val2', 2],
+        [
+            'mysql' => '(`val1` - 1 - `val2` - 2)',
+            'pgsql' => '("val1" - 1 - "val2" - 2)',
+            'sqlite' => '("val1" - 1 - "val2" - 2)',
+            'sqlsrv' => '([val1] - 1 - [val2] - 2)',
+        ],
+    ],
+    'column/expression/...' => [
+        [1, 'val1', 2, 'val2'],
+        [
+            'mysql' => '(1 - `val1` - 2 - `val2`)',
+            'pgsql' => '(1 - "val1" - 2 - "val2")',
+            'sqlite' => '(1 - "val1" - 2 - "val2")',
+            'sqlsrv' => '(1 - [val1] - 2 - [val2])',
+        ],
+    ],
+]);


### PR DESCRIPTION
### Changed
* Arithmetic expressions `Add`, `Subtract`, `Multiply`, `Divide` and `Modulo` now accept variable number of additional arguments beyond the first two